### PR TITLE
Update action.yml for node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ outputs:
   git_branch_name:
     description: 'The current Git branch name'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
The node.js version in this action is outdated – GitHub actions run on node 16 now. This action seems to work just fine on node 16 so this change should only get rid of the following warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: petehouston/github-actions-query-branch-name@v1.2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/